### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/components/logger/index.js
+++ b/components/logger/index.js
@@ -6,7 +6,7 @@
  */
 
 var winston 	= require('winston');
-var uuid 		= require('node-uuid');
+var uuid 		= require('uuid');
 var path		= require('path');
 var config		= require('../../config/environment');
 

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "multer": "^1.1.0",
     "mv": "1.0.0",
     "node-json2html": "~0.4.1",
-    "node-uuid": "^1.4.7",
     "nodemailer": "^2.0.0",
     "passport": "^0.2.2",
     "passport-cas": "0.0.3",
     "pdfkit": "~0.2.7",
     "string-template": "^0.2.1",
+    "uuid": "^3.0.0",
     "winston": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.